### PR TITLE
Pass ShellCheck

### DIFF
--- a/nvi
+++ b/nvi
@@ -92,31 +92,32 @@ function install_node() {
   DOWNLOAD_DIR=$2
   INSTALL_DIR=$3
   BIN_DIR=$4
-  [ ! -d $DOWNLOAD_DIR ] && FRESH_DOWNLOAD_DIR=1
+  [[ ! -d $DOWNLOAD_DIR ]] && FRESH_DOWNLOAD_DIR=1
 
   # Ensure the directories exist.
-  mkdir --parents -- $DOWNLOAD_DIR
-  mkdir --parents -- $INSTALL_DIR
-  mkdir --parents -- $BIN_DIR
+  mkdir --parents -- "$DOWNLOAD_DIR"
+  mkdir --parents -- "$INSTALL_DIR"
+  mkdir --parents -- "$BIN_DIR"
 
   # Download and extract the tar if it doesn't exist on disk.
   if [[ ! -d "$INSTALL_DIR/node-v$NODE_VERSION-linux-x64" ]]; then
     # Fail if version doesn't exist.
     NODE_DIST_LOOKUP=$(wget -qO - https://nodejs.org/dist/index.json | grep --null-data --only-matching --perl-regex --text "\"version\"\s*:\s*\"v$NODE_VERSION\"")
-    [ -z "$NODE_DIST_LOOKUP" ] && >&2 echo "Error: Couldn't find Node.js version v$NODE_VERSION. Aborting." && exit 1
+    [[ -z "$NODE_DIST_LOOKUP" ]] && >&2 echo "Error: Couldn't find Node.js version v$NODE_VERSION. Aborting." && exit 1
     # Download and extract it if it does.
     NODE_TAR="https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz"
-    wget --output-document=$DOWNLOAD_DIR/$NODE_VERSION.tar.gz --quiet $NODE_TAR
-    [ "$?" -ne 0 ] && >&2 echo "Error: Couldn't download $NODE_TAR to ${PWD}/$NODE_VERSION.tar.gz, but the version is valid. Possibly a network or permission issue. Aborting." && exit 1
-    tar --extract --file $DOWNLOAD_DIR/$NODE_VERSION.tar.gz --gzip --directory $INSTALL_DIR
-    rm -- $DOWNLOAD_DIR/$NODE_VERSION.tar.gz
+    if ! wget --output-document="$DOWNLOAD_DIR/$NODE_VERSION.tar.gz" --quiet "$NODE_TAR"; then
+      >&2 echo "Error: Couldn't download $NODE_TAR to ${PWD}/$NODE_VERSION.tar.gz, but the version is valid. Possibly a network or permission issue. Aborting." && exit 1
+    fi
+    tar --extract --file "$DOWNLOAD_DIR/$NODE_VERSION.tar.gz" --gzip --directory "$INSTALL_DIR"
+    rm -- "$DOWNLOAD_DIR/$NODE_VERSION.tar.gz"
     # If the download dir was created by us and is now empty, remove it.
-    [ ! -z $FRESH_DOWNLOAD_DIR ] && [ -z "$(ls -A $DOWNLOAD_DIR)" ] && rm -d -- $DOWNLOAD_DIR
+    [[ ! -z $FRESH_DOWNLOAD_DIR ]] && [[ -z "$(ls -A "$DOWNLOAD_DIR")" ]] && rm -d -- "$DOWNLOAD_DIR"
   fi
 
   # Install executables in the bin dir.
-  cp -- $INSTALL_DIR/node-v$NODE_VERSION-linux-x64/bin/node $BIN_DIR/node
-  ln --force --symbolic -- $(readlink --canonicalize $INSTALL_DIR/node-v$NODE_VERSION-linux-x64/bin/npm) $BIN_DIR/npm
+  cp -- "$INSTALL_DIR/node-v$NODE_VERSION-linux-x64/bin/node" "$BIN_DIR/node"
+  ln --force --symbolic -- "$(readlink --canonicalize "$INSTALL_DIR/node-v$NODE_VERSION-linux-x64/bin/npm")" "$BIN_DIR/npm"
 }
 
 function argument_parser() {
@@ -181,7 +182,7 @@ function argument_parser() {
     fi
   fi
 
-  install_node $NODE_VERSION $DOWNLOAD_DIR $INSTALL_DIR $EXEC_DIR
+  install_node "$NODE_VERSION" "$DOWNLOAD_DIR" "$INSTALL_DIR" "$EXEC_DIR"
 }
 
-argument_parser $*
+argument_parser "$@"


### PR DESCRIPTION
This change set is sufficient to pass [ShellCheck 0.4.5](https://www.shellcheck.net/). Note that the current Ubuntu package is only version 0.4.4 and does not include SC2181.

@emiln asked why SC2181 does not apply to lines 105-106 (`NODE_DIST_LOOKUP=$( ... ); [ -z "$NODE_DIST_LOOKUP" ] ...`. It's a combination of things that make it correct and fixing it would fit better under #5. It's a round-about way of doing conceptually the same thing as the `wget` example that does trigger SC2181, and it's possible to rewrite it that way (and that would be clearer).

Squash everything?