### PR TITLE
Integrate Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+
+language: bash
+
+services:
+  - docker
+
+before_install:
+  - docker pull koalaman/shellcheck:latest
+
+script:
+  - docker run --volume $PWD:/scripts koalaman/shellcheck /scripts/nvi


### PR DESCRIPTION
Run ShellCheck 0.4.4 in Travis. 0.4.5 is not available. :(

I did not hook up Travis. I'll let somebody else decide whether we want this first.