### PR TITLE
Improve Bash style

### DIFF
--- a/nvi
+++ b/nvi
@@ -113,15 +113,12 @@ install_node() {
   # Download and extract the tar if it doesn't exist on disk.
   if [[ ! -d "$INSTALL_DIR/$PACKAGE" ]]; then
     # Fail if version doesn't exist.
-    local NODE_DIST_LOOKUP
-    NODE_DIST_LOOKUP=$(wget -qO - https://nodejs.org/dist/index.json |
+    # --null-data: prevent grep from writing to stdout before wget finishes.
+    wget -qO - https://nodejs.org/dist/index.json |
     grep \
       --null-data \
-      --only-matching \
-      --perl-regex "\"version\"\s*:\s*\"v$NODE_VERSION\"" \
-      --text
-    )
-    [[ -z "$NODE_DIST_LOOKUP" ]] &&
+      --quiet \
+      --perl-regex "\"version\"\s*:\s*\"v$NODE_VERSION\"" ||
       fatal "Couldn't find Node.js version v$NODE_VERSION. Aborting."
 
     # Download and extract it if it does.

--- a/nvi
+++ b/nvi
@@ -140,9 +140,8 @@ install_node() {
       --directory \
       "$INSTALL_DIR"
     rm -- "$DOWNLOAD_DEST"
-    # If the download dir was created by us and is now empty, remove it.
+    # If the download dir was created by us, remove it.
     [[ $FRESH_DOWNLOAD_DIR -eq 1 ]] &&
-      [[ -z "$(ls -A "$DOWNLOAD_DIR")" ]] &&
       rm -d -- "$DOWNLOAD_DIR"
   fi
 

--- a/nvi
+++ b/nvi
@@ -146,14 +146,14 @@ install_node() {
       rm -d -- "$DOWNLOAD_DIR"
   fi
 
+  cd "$INSTALL_DIR/$PACKAGE"
   # Install executables in the bin dir.
-  cp -- "$INSTALL_DIR/$PACKAGE/bin/node" "$BIN_DIR/node"
+  cp -- "bin/node" "$BIN_DIR/node"
   ln \
     --force \
     --symbolic \
     -- \
-    "$(readlink --canonicalize \
-    "$INSTALL_DIR/$PACKAGE/bin/npm")" \
+    "$PWD/bin/npm" \
     "$BIN_DIR/npm"
 }
 

--- a/nvi
+++ b/nvi
@@ -91,6 +91,11 @@ ${B}SEE ALSO${N}
 EOF
 }
 
+fatal() {
+  1>&2 printf 'Error: %s\n' "$1"
+  exit 1
+}
+
 install_node() {
   NODE_VERSION=$1
   DOWNLOAD_DIR=$2
@@ -117,8 +122,8 @@ install_node() {
       --text
     )
     [[ -z "$NODE_DIST_LOOKUP" ]] &&
-      >&2 echo "Error: Couldn't find Node.js version v$NODE_VERSION. Aborting." &&
-      exit 1
+      fatal "Couldn't find Node.js version v$NODE_VERSION. Aborting."
+
     # Download and extract it if it does.
     local ARCHIVE="$PACKAGE.tar.gz"
     local DOWNLOAD_DEST="$DOWNLOAD_DIR/$ARCHIVE"
@@ -128,8 +133,7 @@ install_node() {
       --quiet \
       "$NODE_TAR"
     then
-      >&2 echo "Error: Couldn't download $NODE_TAR to $DOWNLOAD_DEST, but the version is valid. Possibly a network or permission issue. Aborting."
-      exit 1
+      fatal "Couldn't download $NODE_TAR to $DOWNLOAD_DEST, but the version is valid. Possibly a network or permission issue. Aborting."
     fi
     tar \
       --extract \
@@ -185,16 +189,14 @@ argument_parser() {
         shift 2
         ;;
       -v|--version)
-        echo "nvi $NVI_VERSION"
+        printf 'nvi %s\n' "$NVI_VERSION"
         exit 0
         ;;
       -*|--*)
-        >&2 echo "Error: Unsupported flag: ${U}$1${N}. See ${U}nvi${N} ${U}--help${N}"
-        exit 1
+        fatal "Error: Unsupported flag: ${U}$1${N}. See ${U}nvi${N} ${U}--help${N}"
         ;;
       *)
-        >&2 echo "Error: nvi doesn't take arguments apart from its options flags. See ${U}nvi${N} ${U}--help${N}"
-        exit 1
+        fatal "Error: nvi doesn't take arguments apart from its options flags. See ${U}nvi${N} ${U}--help${N}"
         ;;
     esac
   done
@@ -202,8 +204,7 @@ argument_parser() {
   # If no version was given, infer it from package.json.
   if [[ -z "$NODE_VERSION" ]]; then
     if [[ ! -f ./package.json ]]; then
-      >&2 echo "Error: Trying to infer the Node.js version from a package.json file, but ${PWD}/package.json doesn't exist."
-      exit 1
+      fatal "Error: Trying to infer the Node.js version from a package.json file, but ${PWD}/package.json doesn't exist."
     fi
     PACKAGE_JSON_VERSION=$(grep \
       --null-data \
@@ -216,11 +217,10 @@ argument_parser() {
       NODE_VERSION=$PACKAGE_JSON_VERSION
     else
       if [[ -z $PACKAGE_JSON_VERSION ]]; then
-        >&2 echo "Error: Trying to infer the Node.js version from a package.json file, but ${PWD}/package.json has no '.engines.node' property."
+        fatal "Error: Trying to infer the Node.js version from a package.json file, but ${PWD}/package.json has no '.engines.node' property."
       else
-        >&2 echo "Error: Trying to infer the Node.js version from a package.json file, but '$PACKAGE_JSON_VERSION' is not a normal semver."
+        fatal "Error: Trying to infer the Node.js version from a package.json file, but '$PACKAGE_JSON_VERSION' is not a normal semver."
       fi
-      exit 1
     fi
   fi
 

--- a/nvi
+++ b/nvi
@@ -9,7 +9,7 @@ B=$(tput bold) # Bold
 N=$(tput sgr0) # Normal
 U=$(tput smul) # Underline
 
-function print_usage() {
+print_usage() {
   cat << EOF
 ${B}NAME${N}
     Node.js Version Installer $NVI_VERSION - installs Node.js on your system.
@@ -91,7 +91,7 @@ ${B}SEE ALSO${N}
 EOF
 }
 
-function install_node() {
+install_node() {
   NODE_VERSION=$1
   DOWNLOAD_DIR=$2
   INSTALL_DIR=$3
@@ -156,7 +156,7 @@ function install_node() {
     "$BIN_DIR/npm"
 }
 
-function argument_parser() {
+argument_parser() {
   # Set defaults and override them depending on the supplied options.
   NODE_VERSION=""
   DOWNLOAD_DIR=$PWD

--- a/nvi
+++ b/nvi
@@ -97,11 +97,11 @@ fatal() {
 }
 
 install_node() {
-  NODE_VERSION=$1
-  DOWNLOAD_DIR=$2
-  INSTALL_DIR=$3
+  local NODE_VERSION=$1
+  local DOWNLOAD_DIR=$2
+  local INSTALL_DIR=$3
   local PACKAGE="node-v${NODE_VERSION}-linux-x64"
-  BIN_DIR=$4
+  local BIN_DIR=$4
   local FRESH_DOWNLOAD_DIR=0
   [[ ! -d $DOWNLOAD_DIR ]] && FRESH_DOWNLOAD_DIR=1
 
@@ -158,10 +158,10 @@ install_node() {
 
 argument_parser() {
   # Set defaults and override them depending on the supplied options.
-  NODE_VERSION=""
-  DOWNLOAD_DIR=$PWD
-  INSTALL_DIR="$HOME/.local"
-  EXEC_DIR="$HOME/.local/bin"
+  local NODE_VERSION=""
+  local DOWNLOAD_DIR="$PWD"
+  local INSTALL_DIR="$HOME/.local"
+  local EXEC_DIR="$HOME/.local/bin"
   while (( "$#" )); do
     case "$1" in
       -d|--download-directory)

--- a/nvi
+++ b/nvi
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 NVI_VERSION=1.0.0
 B=$(tput bold) # Bold
 N=$(tput sgr0) # Normal
@@ -93,6 +97,7 @@ function install_node() {
   INSTALL_DIR=$3
   local PACKAGE="node-v${NODE_VERSION}-linux-x64"
   BIN_DIR=$4
+  local FRESH_DOWNLOAD_DIR=0
   [[ ! -d $DOWNLOAD_DIR ]] && FRESH_DOWNLOAD_DIR=1
 
   # Ensure the directories exist.
@@ -135,7 +140,7 @@ function install_node() {
       "$INSTALL_DIR"
     rm -- "$DOWNLOAD_DEST"
     # If the download dir was created by us and is now empty, remove it.
-    [[ ! -z $FRESH_DOWNLOAD_DIR ]] &&
+    [[ $FRESH_DOWNLOAD_DIR -eq 1 ]] &&
       [[ -z "$(ls -A "$DOWNLOAD_DIR")" ]] &&
       rm -d -- "$DOWNLOAD_DIR"
   fi


### PR DESCRIPTION
Per #5, this set of changes aims to make `nvi` more idiomatic Bash. They address a few nominal portability and robustness concerns and improve the `--help` experience. Refer to individual commits for details.

Our temporary directory handling is kind of weird, and I wonder as to the purpose of `--download-directory`. Without it we could trivially switch to `mktemp --directory`, but we probably wouldn't even need that -- we could just download to `/tmp`. But since it's there, cleaning up that logic has too low RoI.

By convention, internal variable names use lowercase and environment variables use uppercase. I didn't change that here. There is no functional difference and it touches half the script.

I wrote this script to test with `rebase`:

```sh
#!/bin/bash

set -o errexit
set -o nounset

readonly NVI="${NVI:-$PWD/nvi}"
# 0.10.0 has the expected structure and is very small.
readonly some_node_version="${NODE_VERSION:-0.10.0}"

readonly tmpdir=$(mktemp --directory)
trap 'rm -r $tmpdir' EXIT

readonly download_dir="$tmpdir/d"
readonly install_dir="$tmpdir/i"
readonly exec_dir="$tmpdir/e"

readonly node_bin="$exec_dir/node"
readonly npm_link="$exec_dir/npm"
readonly package_dir="$install_dir/node-v${some_node_version}-linux-x64"

mkdir --parents "$exec_dir" "$install_dir"

"$NVI" \
  --download-directory "$download_dir" \
  --install-directory "$install_dir" \
  --executable-directory "$exec_dir" \
  --node-version "$some_node_version"

failed=0

fail() {
  printf "error: %s\n" "$1"
  failed=1
}

[[ ! -d $download_dir ]] || fail "fresh download directory not removed"

[[ -d $package_dir ]] || fail "no installed package '$package_dir'"

[[ -f $node_bin ]] || fail "no file '$node_bin'"
[[ -x $node_bin ]] || fail "not executable '$node_bin'"

[[ -f $npm_link ]] || fail "no file '$npm_link'"
[[ -L $npm_link ]] || fail "not symlink '$npm_link'"

exit $failed
```