### PR TITLE
Fix -e for relative paths

### DIFF
--- a/nvi
+++ b/nvi
@@ -110,6 +110,8 @@ install_node() {
   mkdir --parents -- "$INSTALL_DIR"
   mkdir --parents -- "$BIN_DIR"
 
+  [[ ! $BIN_DIR = /* ]] && BIN_DIR="$PWD/$BIN_DIR"
+
   # Download and extract the tar if it doesn't exist on disk.
   if [[ ! -d "$INSTALL_DIR/$PACKAGE" ]]; then
     # Fail if version doesn't exist.


### PR DESCRIPTION
In 19ee88f ("Avoid unnecessary readlink") I `cd`'ed out of the working directory but did not account for that in `BIN_PATH`. If that path is relative the installation step breaks. Ensure that `BIN_PATH` is absolute.

Closes #14.

Here is a version of my test script from #11 adjusted to catch this:

```sh
#!/bin/bash

set -o errexit
set -o nounset

readonly NVI="${NVI:-$PWD/nvi}"
# 0.10.0 has the expected structure and is very small.
readonly some_node_version="${NODE_VERSION:-0.10.0}"

failed=0

fail() {
  printf "error: %s\n" "$1"
  failed=1
}

run_in() {
  local -r ctx="$1"
  local -r download_dir="$ctx/d"
  local -r install_dir="$ctx/i"
  local -r exec_dir="$ctx/e"

  printf 'running in %s\n' "$ctx"

  local -r node_bin="$exec_dir/node"
  local -r npm_link="$exec_dir/npm"
  local -r package_dir="$install_dir/node-v${some_node_version}-linux-x64"

  "$NVI" \
    --download-directory "$download_dir" \
    --install-directory "$install_dir" \
    --executable-directory "$exec_dir" \
    --node-version "$some_node_version"

  [[ ! -d $download_dir ]] || fail "fresh download directory '$download_dir' not removed"

  [[ -d $package_dir ]] || fail "no installed package '$package_dir'"

  [[ -f $node_bin ]] || fail "no file '$node_bin'"
  [[ -x $node_bin ]] || fail "not executable '$node_bin'"

  [[ -f $npm_link ]] || fail "no file '$npm_link'"
  [[ -L $npm_link ]] || fail "not symlink '$npm_link'"
}

readonly tmpdir=$(mktemp --directory)
trap 'rm -r $tmpdir' EXIT

run_in "$(mktemp --directory --tmpdir="$tmpdir" tmp.XXX)"
cd "$(mktemp --directory --tmpdir="$tmpdir" tmp.XXX)"
run_in "."

exit $failed
```