### PR TITLE
Improve developer ergonomics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 before_install:
-  - docker pull koalaman/shellcheck:latest
+  - docker pull koalaman/shellcheck:v0.5.0
 
 script:
   - docker run --volume $PWD:/scripts koalaman/shellcheck /scripts/nvi /scripts/test-nvi

--- a/README.md
+++ b/README.md
@@ -7,18 +7,16 @@ A command-line tool to make Node.js binaries available in CI environments.
 OS | Will it work?
 -- | --
 GNU/Linux | :white_check_mark: **Yes**. Just ensure you have all the GNU software mentioned below.
-macOS | :warning: **Probably**. The coreutils shipped with OS X do not work, but you can install the GNU versions using [brew](https://brew.sh/).
-Windows | :white_check_mark: **With Bash for Windows, yes**. We've successfully used `nvi` in Bash for Windows. It works out of the box.
+macOS | :warning: **With some effort**. The coreutils shipped with OS X do not work, but you can install the GNU versions using [brew](https://brew.sh/).
+Windows | :warning: **With Bash for Windows, yes**. We've successfully used `nvi` in Bash for Windows. It works out of the box.
 
 In order to run, `nvi` assumes the following software is available:
 
 *   GNU coreutils
 *   Other GNU software: `bash`, `grep`, `tar`, `tput`, `wget`
 
-These are available in most GNU/Linux distributions and certainly through their
+These are available in many GNU/Linux distributions and certainly through their
 various package managers.
-
-**Note**: `nvi` is tested on Ubuntu 16.04 and only Ubuntu 16.04.
 
 ## Can't I just use nvm?
 

--- a/nvi
+++ b/nvi
@@ -98,19 +98,22 @@ fatal() {
 
 install_node() {
   local NODE_VERSION=$1
-  local DOWNLOAD_DIR=$2
-  local INSTALL_DIR=$3
+  local DOWNLOAD_DIR
+  DOWNLOAD_DIR=$(readlink --canonicalize-missing "$2")
+  local INSTALL_DIR
+  INSTALL_DIR=$(readlink --canonicalize-missing "$3")
+  local EXEC_DIR
+  EXEC_DIR=$(readlink --canonicalize-missing "$4")
   local PACKAGE="node-v${NODE_VERSION}-linux-x64"
-  local BIN_DIR=$4
   local FRESH_DOWNLOAD_DIR=0
   [[ ! -d $DOWNLOAD_DIR ]] && FRESH_DOWNLOAD_DIR=1
 
   # Ensure the directories exist.
   mkdir --parents -- "$DOWNLOAD_DIR"
   mkdir --parents -- "$INSTALL_DIR"
-  mkdir --parents -- "$BIN_DIR"
+  mkdir --parents -- "$EXEC_DIR"
 
-  [[ ! $BIN_DIR = /* ]] && BIN_DIR="$PWD/$BIN_DIR"
+  [[ ! $EXEC_DIR = /* ]] && EXEC_DIR="$PWD/$EXEC_DIR"
 
   # Download and extract the tar if it doesn't exist on disk.
   if [[ ! -d "$INSTALL_DIR/$PACKAGE" ]]; then
@@ -120,7 +123,7 @@ install_node() {
     grep \
       --null-data \
       --quiet \
-      --perl-regex "\"version\"\s*:\s*\"v$NODE_VERSION\"" ||
+      "\"version\"\\s*:\\s*\"v$NODE_VERSION\"" ||
       fatal "Couldn't find Node.js version v$NODE_VERSION. Aborting."
 
     # Download and extract it if it does.
@@ -149,13 +152,24 @@ install_node() {
 
   cd "$INSTALL_DIR/$PACKAGE"
   # Install executables in the bin dir.
-  cp -- "bin/node" "$BIN_DIR/node"
-  ln \
+  if ln \
     --force \
     --symbolic \
     -- \
-    "$PWD/bin/npm" \
-    "$BIN_DIR/npm"
+    "$INSTALL_DIR/$PACKAGE/bin/node" \
+    "$EXEC_DIR/node"
+  then
+    ln \
+      --force \
+      --symbolic \
+      -- \
+      "$INSTALL_DIR/$PACKAGE/bin/npm" \
+      "$EXEC_DIR/npm"
+  else
+    fatal "Couldn't write to symlink \"$EXEC_DIR/node\". Possibly a permission issue. Aborting."
+  fi
+
+  echo "Successfully installed Node.js version \"$NODE_VERSION\"."
 }
 
 argument_parser() {
@@ -190,7 +204,7 @@ argument_parser() {
         printf 'nvi %s\n' "$NVI_VERSION"
         exit 0
         ;;
-      -*|--*)
+      -*)
         fatal "Error: Unsupported flag: ${U}$1${N}. See ${U}nvi${N} ${U}--help${N}"
         ;;
       *)
@@ -207,10 +221,10 @@ argument_parser() {
     PACKAGE_JSON_VERSION=$(grep \
       --null-data \
       --only-matching \
-      --perl-regex \
       --text \
       '"engines":\s*{\s*"node":\s*"\K[^"]*' \
-      ./package.json)
+      ./package.json |
+      tr '\0' '\n')
     if [[ $PACKAGE_JSON_VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       NODE_VERSION=$PACKAGE_JSON_VERSION
     else

--- a/test-nvi
+++ b/test-nvi
@@ -16,7 +16,7 @@ readonly some_node_version="${NODE_VERSION:-0.10.0}"
 failed=0
 
 fail() {
-  printf "error: %s\n" "$1"
+  printf "error: %s\\n" "$1"
   failed=1
 }
 
@@ -44,10 +44,12 @@ run_in() {
   [[ -d $package_dir ]] || fail "no installed package '$package_dir'"
 
   [[ -f $node_bin ]] || fail "no file '$node_bin'"
+  [[ -L $node_bin ]] || fail "not symlink '$node_bin'"
   [[ -x $node_bin ]] || fail "not executable '$node_bin'"
 
   [[ -f $npm_link ]] || fail "no file '$npm_link'"
   [[ -L $npm_link ]] || fail "not symlink '$npm_link'"
+  [[ -x $npm_link ]] || fail "not executable '$npm_link'"
 }
 
 readonly tmpdir="$(mktemp --directory)"


### PR DESCRIPTION
Fixes #17, #18, #19

Several members of our team are now using nvi for their daily
development workflow, which has brought some less than ergonomic traits
of nvi to the surface. See the referenced issues for a more thorough
explanation.

While these issues are mostly irrelevant in a CI setting, which is the
intended environment of nvi, there is no harm in fixing them. This
commit addresses all three issues:

1. There should be no more warnings about null bytes in input.
2. If creating the node symlink fails, nvi doesn't attempt to create the
   npm symlink.
3. The node executable is now a symlink (like the npm executable), which
   means nvi can change it even when the linked node executable is
   running.

The fix of (3) in particular should greatly improve the experience of
using nvi in development workflows.