### PR TITLE
Fix broken reg-exp

### DIFF
--- a/nvi
+++ b/nvi
@@ -221,6 +221,7 @@ argument_parser() {
     PACKAGE_JSON_VERSION=$(grep \
       --null-data \
       --only-matching \
+      --perl-regexp \
       --text \
       '"engines":\s*{\s*"node":\s*"\K[^"]*' \
       ./package.json |


### PR DESCRIPTION
#21

In our great clean-up zeal we noticed the use of the flag "--perl-regex"
and removed it, since the proper flag is "--perl-regexp" with a trailing
"p", and we hence assumed the flag had been a no-op.

It turns out the flag *was* being used, and that it *is* required, since
we use "\K" (Keep Out) to drop everything matched so far. This feature
is not available in the basic reg-exp mode, which necessitates the use
of PCRE.

We should probably extend our test suite at some point to cover the very
common case of installing by reading package.json.