### PR TITLE
Link npx executable alongside npm and node

### DIFF
--- a/nvi
+++ b/nvi
@@ -165,6 +165,14 @@ install_node() {
       -- \
       "$INSTALL_DIR/$PACKAGE/bin/npm" \
       "$EXEC_DIR/npm"
+    # npx has only been included since npm 5.2.0 so we avoid creating a link to it if it does not exist.
+    [[ -f "$INSTALL_DIR/$PACKAGE/bin/npx" ]] &&
+      ln \
+        --force \
+        --symbolic \
+        -- \
+        "$INSTALL_DIR/$PACKAGE/bin/npx" \
+        "$EXEC_DIR/npx"
   else
     fatal "Couldn't write to symlink \"$EXEC_DIR/node\". Possibly a permission issue. Aborting."
   fi


### PR DESCRIPTION
Since npm@5.2.0 we have been getting npx installed as well as node and
npm. It is about time we also include this when installing node with
nvi, since we have taken to using it for local development as well as
the CI setup it was originally intended for.

This does not fix the issue with globally installed packages mentioned
in #23, but it does help circumvent it, since you can run things through
npx for most of these cases.